### PR TITLE
Make stylesheet path relative to root

### DIFF
--- a/views/layout.haml
+++ b/views/layout.haml
@@ -4,7 +4,7 @@
     %script{ :src => 'https://code.jquery.com/jquery-2.1.4.js', :type => 'text/javascript', :charset => 'utf-8' }
     %script{ :src => 'https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore.js', :type => 'text/javascript', :charset => 'utf-8' }
     %script{ type: "text/javascript", src: "js/infinity.js" }
-    %link{:rel => :stylesheet, :type => :"text/css", :href => "css/styles.css"}
+    %link{:rel => :stylesheet, :type => :"text/css", :href => "/css/styles.css"}
     %link{ :href => "http://fonts.googleapis.com/css?family=Rubik:400,300,300italic,400italic,500,700,900", :rel => :stylesheet, :type => :"text/css"}
   %body
   %h1 KARAOKE


### PR DESCRIPTION
Having the CSS path be relative to the PWD made the app try to load
stylesheets from wonky paths e.g. going to /play/a/song would try to
load /play/a/stylesheet.css, or something like that.
