### PR TITLE
Close up next tab after play

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -124,6 +124,8 @@ end
 get '/finish_between' do
   show_mpv
   play_mpv
+
+  haml :finish_between
 end
 
 get '/skip_current' do

--- a/public/js/finish_between.js
+++ b/public/js/finish_between.js
@@ -1,0 +1,1 @@
+window.close();

--- a/views/finish_between.haml
+++ b/views/finish_between.haml
@@ -1,0 +1,1 @@
+%script{type: "text/javascript", src: "js/finish_between.js"}


### PR DESCRIPTION
Before this change, the karaoke machine tabs would accumulate with each
play. This keeps that down!
