### PR TITLE
"Skip current" removes current playlist entry

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -228,7 +228,7 @@ def make_playlist_command
 end
 
 def skip_to_next_track_command
-  { "command" => ["playlist-next"] }.to_json
+  { "command" => ["playlist-remove", "current"] }.to_json
 end
 
 def play_song_by_id(song_index)


### PR DESCRIPTION
Formerly, tried to do "next track", which didn't work for the last track.
